### PR TITLE
make music gesture summary straightforward

### DIFF
--- a/configpanel/res/values/strings.xml
+++ b/configpanel/res/values/strings.xml
@@ -33,8 +33,8 @@
     <string name="touchscreen_flashlight_gesture_summary">Draw a \'V\' to toggle flashlight</string>
     <string name="touchscreen_music_gesture_summary">Use gestures to control music playback \n
     • Two fingers vertically to play/pause\n
-    • Draw left arrow for previous track\n
-    • Draw right arrow for next track</string>
+    • Draw left arrow (\'&#60;\') for previous track\n
+    • Draw right arrow (\'&#62;\') for next track</string>
 
     <!-- O-Click settings -->
     <string name="oclick_panel_title" translatable="false">O-Click</string>


### PR DESCRIPTION
First time users might actually misunderstand left/right arrow by trying
to draw  -> / <- etc and end up not knowing how it works. Show the exact
gesture in summary itself to avoid confusions.

Change-Id: Ibde518a14f0947a15073fbef5ee6bd487e326e0c